### PR TITLE
fix: temporary use color attribute as textarea

### DIFF
--- a/src/components/attribute-input.tsx
+++ b/src/components/attribute-input.tsx
@@ -9,6 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import type { Attribute } from "@/types/attributes";
 
 export function AttributeInput({
@@ -55,8 +56,12 @@ export function AttributeInput({
     case "time": {
       return <Input type="time" {...field} />;
     }
+    // case "color": {
+    //   return <Input type="color" className="h-16 w-full" {...field} />;
+    // }
+    // Temporary use textarea for color input
     case "color": {
-      return <Input type="color" className="h-16 w-full" {...field} />;
+      return <Textarea rows={3} {...field} />;
     }
     case "checkbox": {
       return (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -27,9 +27,15 @@ export function getSchemaObjectForAttribute(attribute: Attribute) {
           message: `Pole ${attribute.name} musi być adresem email`,
         });
     }
+    // case "color": {
+    //   return z.string({
+    //     required_error: `Wybierz kolor dla pola ${attribute.name}.`,
+    //   });
+    // }
+    // Temporary use textarea for color input
     case "color": {
       return z.string({
-        required_error: `Wybierz kolor dla pola ${attribute.name}.`,
+        required_error: `To pole nie może być puste.`,
       });
     }
     case "number": {


### PR DESCRIPTION
don't ask why
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Temporarily replace 'color' input with `Textarea` in `AttributeInput` and update schema validation for 'color' attributes.
> 
>   - **Behavior**:
>     - Temporarily replace `Input` type 'color' with `Textarea` in `AttributeInput` for 'color' attributes.
>     - Update error message for 'color' attributes in `getSchemaObjectForAttribute` to "To pole nie może być puste."
>   - **Code**:
>     - Comment out original 'color' handling code in `attribute-input.tsx` and `utils.ts`.
>     - Add `Textarea` import in `attribute-input.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for 0a5c97d7ed5e5f66072764bba2fde11348bc4abf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->