### PR TITLE
chore: remove toast after successful submitting form

### DIFF
--- a/src/app/[eventSlug]/register-participant-form.tsx
+++ b/src/app/[eventSlug]/register-participant-form.tsx
@@ -46,12 +46,7 @@ export function RegisterParticipantForm({ event }: { event: Event }) {
   ) {
     try {
       const result = await registerParticipant(values, event);
-      if (result.success) {
-        toast({
-          title: "Rejestracja na wydarzenie powiodła się",
-          description: "Zostałeś dodany do wydarzenia",
-        });
-      } else {
+      if (!result.success) {
         toast({
           variant: "destructive",
           title: "Rejestracja na wydarzenie nie powiodła się",

--- a/src/app/[eventSlug]/register-participant-form.tsx
+++ b/src/app/[eventSlug]/register-participant-form.tsx
@@ -47,6 +47,11 @@ export function RegisterParticipantForm({ event }: { event: Event }) {
     try {
       const result = await registerParticipant(values, event);
       if (!result.success) {
+        form.setError("root", {
+          type: "manual",
+          message:
+            "Rejestracja na wydarzenie nie powiodła się.\nSpróbuj ponownie później",
+        });
         toast({
           variant: "destructive",
           title: "Rejestracja na wydarzenie nie powiodła się",
@@ -142,6 +147,12 @@ export function RegisterParticipantForm({ event }: { event: Event }) {
             )}
           />
         ))}
+
+        {form.formState.errors.root?.message != null && (
+          <FormMessage className="whitespace-break-spaces text-center text-sm text-red-500">
+            {form.formState.errors.root.message}
+          </FormMessage>
+        )}
 
         <Button
           type="submit"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove success toast notification and display error messages within `RegisterParticipantForm` on failure.
> 
>   - **Behavior**:
>     - Removed success toast notification after form submission in `RegisterParticipantForm`.
>     - Displays error message within form if registration fails, using `form.setError`.
>   - **UI**:
>     - Adds `FormMessage` to display error messages in the form.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for 8d104326c6fe0facfd25a5f9647d73ac3de8d7af. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->