### PR TITLE
fix: make having brain optional

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -37,6 +37,9 @@ export function getSchemaObjectForAttribute(attribute: Attribute) {
     // }
     // Temporary use textarea for color input
     case "color": {
+      if (attribute.slug === "thoughts") {
+        return z.string().optional();
+      }
       return z.string({
         required_error: `To pole nie może być puste.`,
       });


### PR DESCRIPTION
This pull request includes a small change to the `src/lib/utils.ts` file. The change adds a condition to the `getSchemaObjectForAttribute` function to return an optional string for attributes with the slug "thoughts".

* [`src/lib/utils.ts`](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224R40-R42): Added a condition to return `z.string().optional()` for attributes with the slug "thoughts" in the `getSchemaObjectForAttribute` function.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add condition in `getSchemaObjectForAttribute` to make 'thoughts' attribute optional in `utils.ts`.
> 
>   - **Behavior**:
>     - In `getSchemaObjectForAttribute` in `utils.ts`, added condition to return `z.string().optional()` for attributes with slug "thoughts".
>   - **Misc**:
>     - No other changes or refactoring in the file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for 45eb0efa722af7733597416abb3bdc39f4d3635c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->