### PR TITLE
fix: add 'engines' to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "prettier": "^3.5.0",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }


### PR DESCRIPTION
Dodaje property engines to package.json, explicitly ustawiając wersję node'a na której powinna działać aplikacja na wersje większą lub równą v20. Zmiana potrzebna po to aby działało [API 'File'](https://nodejs.org/api/buffer.html#class-file) po stronie serwera, co jest wspierane dopiero od wersji 20 node'a i jest wykorzystywane w server action do zdjęcia eventu przy jego tworzeniu
https://github.com/Solvro/web-eventownik-v2/blob/5ec0479b171bcc1b8fbcbdf2c9abf59786849a6e/src/app/dashboard/(create-event)/actions.ts#L42
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `engines` property to `package.json` to require Node.js version `>=20.0.0` for compatibility with `File` API.
> 
>   - **Behavior**:
>     - Adds `engines` property to `package.json` to specify Node.js version `>=20.0.0`.
>     - Ensures compatibility with `File` API used in server-side event creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for c1e587711622e1c0e33558b8832b48cabe6ee299. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->