### PR TITLE
fix: add proper handling of empty 'event.image'

### DIFF
--- a/src/app/dashboard/(create-event)/(steps)/attributes.tsx
+++ b/src/app/dashboard/(create-event)/(steps)/attributes.tsx
@@ -87,7 +87,7 @@ export function AttributesForm({
 
   async function createEvent() {
     setLoading(true);
-    const base64Image = await getBase64FromUrl(event.image);
+    const base64Image = event.image ? await getBase64FromUrl(event.image) : "";
     const newEventObject = { ...event, attributes, image: base64Image };
     try {
       const result = await saveEvent(newEventObject);

--- a/src/app/dashboard/(create-event)/actions.ts
+++ b/src/app/dashboard/(create-event)/actions.ts
@@ -35,7 +35,7 @@ export async function saveEvent(event: Event) {
   formData.append("primaryColor", event.color);
   formData.append("participantsCount", event.participantsNumber.toString());
 
-  if (event.image !== "") {
+  if (event.image) {
     const photo = await fetch(event.image)
       .then(async (response) => response.blob())
       .then((blob) => {


### PR DESCRIPTION
Nie było sprawdzane czy `event.image` jest pustym stringiem (czyli przypadek gdzie nie ustawiono zdjęcia w stepie z personalizacją), więc jak nie było obrazka to wewnątrz `getBase64FromUrl` fetchowało pusty string, a wtedy najwyraźniej js sobie fetchuje stronę z której był wykonany ten request więc enkodowało cały plik html strony w base64 i próbowało wysłać to jako to zdjęcie :trollface:

plus dodatkowo został lekko uproszczony warunek w ifie bo pusty string jest falsy, więc wystarczy sprawdzać czy samo `event.image` jest truthy
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix handling of empty `event.image` in `createEvent` and `saveEvent` by checking if `event.image` is truthy before processing.
> 
>   - **Behavior**:
>     - Fix handling of empty `event.image` in `createEvent` in `attributes.tsx` by checking if `event.image` is truthy before calling `getBase64FromUrl`.
>     - In `saveEvent` in `actions.ts`, simplify condition to check if `event.image` is truthy before fetching the image.
>   - **Misc**:
>     - Simplified conditional checks for `event.image` in both `attributes.tsx` and `actions.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for 416bc4571230a485b61bef8a21a4ced56ebebbbc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->