### PR TITLE
fix: add y gap in event public view

### DIFF
--- a/src/app/[eventSlug]/page.tsx
+++ b/src/app/[eventSlug]/page.tsx
@@ -87,8 +87,8 @@ export default async function EventPage({ params }: EventPageProps) {
                 </EventInfoDiv>
                 <EventInfoDiv>{format(event.endDate, "HH:mm")}</EventInfoDiv>
               </div>
-              {event.location ? (
-                <div className="flex flex-wrap gap-x-2">
+              <div className="flex flex-wrap gap-2">
+                {event.location ? (
                   <Link
                     href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.location)}`}
                     target="_blank"
@@ -97,11 +97,13 @@ export default async function EventPage({ params }: EventPageProps) {
                       <MapPin size={20} /> {event.location}
                     </EventInfoDiv>
                   </Link>
+                ) : null}
+                {event.organizer ? (
                   <EventInfoDiv>
                     <Building2 size={20} /> {event.organizer}
                   </EventInfoDiv>
-                </div>
-              ) : null}
+                ) : null}
+              </div>
             </div>
             <p className="max-h-72 overflow-y-auto whitespace-pre-line leading-relaxed">
               {event.description}

--- a/src/app/dashboard/events/[id]/page.tsx
+++ b/src/app/dashboard/events/[id]/page.tsx
@@ -73,7 +73,9 @@ export default async function DashboardEventPage({
             </div>
           ) : null}
         </div>
-        {event.description ? <p>{event.description}</p> : null}
+        {event.description ? (
+          <p className="whitespace-pre-line">{event.description}</p>
+        ) : null}
         <div className="flex flex-col gap-2 md:flex-row">
           <Button asChild>
             <Link href={`/dashboard/events/${id}/settings`}>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add vertical gaps and handle whitespace in event descriptions for better layout in event pages.
> 
>   - **Styling Adjustments**:
>     - In `page.tsx` for `src/app/[eventSlug]`, added `gap-2` to the `div` containing location and organizer information to ensure consistent spacing.
>     - In `page.tsx` for `src/app/dashboard/events/[id]`, added `whitespace-pre-line` to the event description `p` tag to preserve line breaks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for 564839fff08091fa092b8445f01ca69d3ef15baf. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->