### PR TITLE
feat: event sharing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@radix-ui/react-switch": "^1.1.3",
         "@radix-ui/react-tabs": "^1.1.3",
         "@radix-ui/react-toast": "^1.2.6",
+        "@radix-ui/react-tooltip": "^1.1.8",
         "@tanstack/react-table": "^8.21.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2274,6 +2275,40 @@
         "@radix-ui/react-use-callback-ref": "1.1.0",
         "@radix-ui/react-use-controllable-state": "1.1.0",
         "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.1.8.tgz",
+      "integrity": "sha512-YAA2cu48EkJZdAMHC0dqo9kialOcRStbtiY4nJPaht7Ptrhcvpo+eDChaM6BIs8kL6a8Z5l5poiqLnXcNduOkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.2",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
         "@radix-ui/react-visually-hidden": "1.1.2"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-switch": "^1.1.3",
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-toast": "^1.2.6",
+    "@radix-ui/react-tooltip": "^1.1.8",
     "@tanstack/react-table": "^8.21.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/dashboard/events/[id]/page.tsx
+++ b/src/app/dashboard/events/[id]/page.tsx
@@ -3,7 +3,6 @@ import {
   Calendar1,
   CalendarX,
   MapPin,
-  Share2Icon,
   SquarePenIcon,
   User,
   Users,
@@ -14,6 +13,7 @@ import { notFound, redirect } from "next/navigation";
 
 import EventPhotoPlaceholder from "@/../public/event-photo-placeholder.png";
 import { Button } from "@/components/ui/button";
+import { ShareButton } from "@/components/ui/share-button";
 import { API_URL, PHOTO_URL } from "@/lib/api";
 import { verifySession } from "@/lib/session";
 import type { Event } from "@/types/event";
@@ -82,9 +82,7 @@ export default async function DashboardEventPage({
               <SquarePenIcon /> Edytuj wydarzenie
             </Link>
           </Button>
-          <Button variant="outline">
-            <Share2Icon /> Udostępnij
-          </Button>
+          <ShareButton url={`https://eventownik.solvro.pl/${event.slug}`} />
         </div>
       </div>
       <Image

--- a/src/components/ui/share-button.tsx
+++ b/src/components/ui/share-button.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { Share2Icon } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+interface ShareButtonProps {
+  url: string;
+  className?: string;
+}
+
+export function ShareButton({ url, className }: ShareButtonProps) {
+  const [isCopied, setIsCopied] = useState(false);
+
+  useEffect(() => {
+    if (isCopied) {
+      const timer = setTimeout(() => {
+        setIsCopied(false);
+      }, 2000);
+      return () => {
+        clearTimeout(timer);
+      };
+    }
+  }, [isCopied]);
+
+  const handleCopy = () => {
+    navigator.clipboard
+      .writeText(url)
+      .then(() => {
+        setIsCopied(true);
+      })
+      .catch((error: unknown) => {
+        console.error("Copy failed:", error);
+      });
+  };
+
+  return (
+    <Tooltip.Provider>
+      <Tooltip.Root open={isCopied}>
+        <Tooltip.Trigger asChild>
+          <Button variant="outline" onClick={handleCopy} className={className}>
+            <Share2Icon className="mr-2 h-4 w-4" />
+            Udostępnij
+          </Button>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content
+            className="rounded bg-gray-900 px-2 py-1 text-sm text-white"
+            sideOffset={5}
+          >
+            Skopiowano do schowka!
+            <Tooltip.Arrow className="fill-gray-900" />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  );
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduces `ShareButton` component for event URL sharing with clipboard copy and tooltip feedback, integrated into `DashboardEventPage`.
> 
>   - **Feature**:
>     - Adds `ShareButton` component in `share-button.tsx` to copy event URL to clipboard with tooltip feedback.
>     - Integrates `ShareButton` into `DashboardEventPage` to replace the previous share button.
>   - **Dependencies**:
>     - Adds `@radix-ui/react-tooltip` to `package.json` for tooltip functionality in `ShareButton`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for 4508aa24a07df94806d799c002ab077c53041f0c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->