### PR TITLE
(Participants table) Fix selecting rows and change edit-form view in table

### DIFF
--- a/src/app/dashboard/events/[id]/participants/table/columns.tsx
+++ b/src/app/dashboard/events/[id]/participants/table/columns.tsx
@@ -25,10 +25,10 @@ export function generateColumns(attributes: Attribute[]) {
         <Checkbox
           checked={
             table.getIsAllRowsSelected() ||
-            (table.getIsSomePageRowsSelected() && "indeterminate")
+            (table.getIsSomeRowsSelected() && "indeterminate")
           }
           onCheckedChange={(value) => {
-            table.toggleAllPageRowsSelected(!!(value as boolean));
+            table.toggleAllRowsSelected(!!(value as boolean));
           }}
           aria-label="Wybierz wszystkie"
         ></Checkbox>

--- a/src/app/dashboard/events/[id]/participants/table/edit-participant-form.tsx
+++ b/src/app/dashboard/events/[id]/participants/table/edit-participant-form.tsx
@@ -63,7 +63,7 @@ export function EditParticipantForm({
   }
 
   return (
-    <form className="my-2 flex flex-col items-center gap-y-2 justify-self-center">
+    <form className="my-2 flex items-center gap-x-2 justify-self-center">
       {cells.map((cell) => {
         const attribute = cell.column.columnDef.meta?.attribute;
         return attribute === undefined ? null : (

--- a/src/app/dashboard/events/[id]/participants/table/participants-table.tsx
+++ b/src/app/dashboard/events/[id]/participants/table/participants-table.tsx
@@ -74,6 +74,7 @@ export function ParticipantTable({
       globalFilter,
     },
     initialState: {
+      //TODO allow user to define page size
       pagination: { pageSize: 15, pageIndex: 0 },
       columnVisibility: {
         id: false,
@@ -229,6 +230,12 @@ export function ParticipantTable({
                   })}
                 </TableRow>
                 {row.getIsExpanded() ? (
+                  /*
+                  TODO Refactor expanded row so it shows only attributes which weren't visible before expanding 
+                   (attribute.showInList = false)
+                   It will require changes in how the edit form will be handled
+                   Use FlattenedParticipant.mode property to render proper UI (editForm/cells)
+                   */
                   <TableRow
                     key={`${row.id}-edit`}
                     className="border-l-primary border-l-2"

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -69,7 +69,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "text-muted-foreground h-10 px-2 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      "text-muted-foreground h-10 px-2 text-left align-middle font-medium [&:has([role=checkbox])]:pr-1 [&>[role=checkbox]]:translate-y-[2px]",
       className,
     )}
     {...props}

--- a/src/types/participant.ts
+++ b/src/types/participant.ts
@@ -15,6 +15,7 @@ export interface FlattenedParticipant {
   slug: string;
   createdAt: string;
   updatedAt: string;
+  //key is attribute id
   [key: string]: string | number | boolean | Date | null | undefined;
   mode: "edit" | "view";
 }


### PR DESCRIPTION
- naprawiłem wybieranie wierszy w tabeli - zaznaczenie selecta w headerze tabeli zaznacza wszystkie wiersze (nie tylko te, które są widoczne na danej stronie tabeli)
- zmieniłem wyświetlanie formularza (`flex-col`-> `flex-row`)
- dodałem komentarze z TODO co trzeba jeszcze zrobić, żeby było zgodnie z designami
   - wyświetlanie atrybutów z polem `showInList = false`
      - odpowiednie handlowanie wejścia w tryb edytowania uczestnika
   - ewentualne przeniesienie logiki renderowania komórek tabeli z `participants-table.tsx` do osobnego komponentu
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes row selection and changes edit form layout in participants table, adds TODOs for future improvements.
> 
>   - **Behavior**:
>     - Fixes row selection in `columns.tsx` by changing `toggleAllPageRowsSelected` to `toggleAllRowsSelected` to select all rows, not just visible ones.
>     - Changes edit form layout in `edit-participant-form.tsx` from `flex-col` to `flex-row`.
>   - **Comments**:
>     - Adds TODO comments in `participants-table.tsx` to handle attributes with `showInList = false` and to consider moving table cell rendering logic to a separate component.
>   - **Misc**:
>     - Adjusts padding in `table.tsx` for checkbox alignment in table headers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for da4c7a989ded44408117fd7debef9e5b1d59fa5d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->