### PR TITLE
feat: show createdAt in participants table

### DIFF
--- a/src/app/dashboard/events/[id]/participants/table/columns.tsx
+++ b/src/app/dashboard/events/[id]/participants/table/columns.tsx
@@ -59,6 +59,20 @@ export function generateColumns(attributes: Attribute[]) {
       },
       cell: (info) => info.getValue(),
     }),
+    columnHelper.accessor("createdAt", {
+      header: ({ column }) => {
+        const sortingDirection = column.getIsSorted();
+        return (
+          <div className="flex items-center">
+            <SortButton sortingDirection={sortingDirection} column={column}>
+              Data registracji
+            </SortButton>
+            <SortIcon sortingDirection={sortingDirection} />
+          </div>
+        );
+      },
+      cell: (info) => info.getValue(),
+    }),
   ];
 
   const attributeColumns = [

--- a/src/app/dashboard/events/[id]/participants/table/participants-table.tsx
+++ b/src/app/dashboard/events/[id]/participants/table/participants-table.tsx
@@ -207,8 +207,9 @@ export function ParticipantTable({
             const attributesCells = allVisibleCells.filter(
               (cell) => cell.column.columnDef.meta?.attribute !== undefined,
             );
-            //headers structure - [select, email, ...attributes, expand]
+            //headers structure - [select, email, createdAt, ...attributes, expand]
             const emailCell = allVisibleCells.at(1);
+            const createdAtCell = allVisibleCells.at(2);
             return (
               <Fragment key={row.id}>
                 <TableRow>
@@ -258,6 +259,14 @@ export function ParticipantTable({
                         : flexRender(
                             emailCell.column.columnDef.cell,
                             emailCell.getContext(),
+                          )}
+                    </TableCell>
+                    <TableCell>
+                      {createdAtCell === undefined
+                        ? null
+                        : flexRender(
+                            createdAtCell.column.columnDef.cell,
+                            createdAtCell.getContext(),
                           )}
                     </TableCell>
                     <TableCell className="p-0" colSpan={attributesCells.length}>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `createdAt` column to participants table with sorting functionality in `columns.tsx` and `participants-table.tsx`.
> 
>   - **Behavior**:
>     - Add `createdAt` column to participants table in `columns.tsx` and `participants-table.tsx`.
>     - Allows sorting by registration date using `SortButton` and `SortIcon` in the header.
>   - **Table Structure**:
>     - Update header structure to include `createdAt` between `email` and attributes in `participants-table.tsx`.
>     - Render `createdAt` cell in both main and expanded rows in `participants-table.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for 3084f5456164da10de92b0ce37a36d024c014c03. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->