### PR TITLE
refactor: change table component markup

### DIFF
--- a/src/app/dashboard/events/[id]/emails/(table)/table.tsx
+++ b/src/app/dashboard/events/[id]/emails/(table)/table.tsx
@@ -26,51 +26,50 @@ function EmailHistoryTable({ email }: { email: SingleEventEmail }) {
   });
 
   return (
-    <Table>
-      <TableHeader>
-        {table.getHeaderGroups().map((headerGroup) => (
-          <TableRow key={headerGroup.id}>
-            {headerGroup.headers.map((header) => {
-              return (
-                <TableHead key={header.id}>
-                  {header.isPlaceholder
-                    ? null
-                    : flexRender(
-                        header.column.columnDef.header,
-                        header.getContext(),
-                      )}
-                </TableHead>
-              );
-            })}
-          </TableRow>
-        ))}
-      </TableHeader>
-      <TableBody>
-        {table.getRowModel().rows.length > 0 ? (
-          table.getRowModel().rows.map((row) => (
-            <TableRow
-              key={row.id}
-              data-state={row.getIsSelected() && "selected"}
-            >
-              {row.getVisibleCells().map((cell) => (
-                <TableCell key={cell.id}>
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </TableCell>
-              ))}
+    <div className="relative max-h-48 overflow-y-auto">
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                return (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                );
+              })}
             </TableRow>
-          ))
-        ) : (
-          <TableRow>
-            <TableCell
-              colSpan={columns.length}
-              className="text-muted h-24 text-center"
-            >
-              Brak wyników
-            </TableCell>
-          </TableRow>
-        )}
-      </TableBody>
-    </Table>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows.length > 0 ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow key={row.id}>
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell
+                colSpan={columns.length}
+                className="text-muted h-24 text-center"
+              >
+                Brak wyników
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
   );
 }
 

--- a/src/app/dashboard/events/[id]/emails/(table)/table.tsx
+++ b/src/app/dashboard/events/[id]/emails/(table)/table.tsx
@@ -26,7 +26,7 @@ function EmailHistoryTable({ email }: { email: SingleEventEmail }) {
   });
 
   return (
-    <div className="relative max-h-48 overflow-y-auto">
+    <div className="relative max-h-72 overflow-y-auto">
       <Table>
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (

--- a/src/app/dashboard/events/[id]/participants/table/participants-table.tsx
+++ b/src/app/dashboard/events/[id]/participants/table/participants-table.tsx
@@ -78,7 +78,7 @@ export function ParticipantTable({
       globalFilter,
     },
     initialState: {
-      //TODO allow user to define page size
+      // TODO: Allow user to define page size
       pagination: { pageSize: 15, pageIndex: 0 },
       columnVisibility: {
         id: false,
@@ -179,124 +179,129 @@ export function ParticipantTable({
           </div>
         </div>
       </div>
-      {/* //TODO prevent resizing width of columns */}
-      <Table>
-        <TableHeader className="border-border border-b-2">
-          {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id}>
-              {headerGroup.headers.map((header) => {
-                return (
-                  <TableHead
-                    key={header.id}
-                    className={cn(
-                      "border-border border-r-2",
-                      header.id === "expand" ? "w-16 text-right" : "",
-                    )}
-                  >
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </TableHead>
-                );
-              })}
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody>
-          {table.getRowModel().rows.map((row) => {
-            const allVisibleCells = row.getVisibleCells();
-            const attributesCells = allVisibleCells.filter(
-              (cell) => cell.column.columnDef.meta?.attribute !== undefined,
-            );
-            //headers structure - [select, email, createdAt, ...attributes, expand]
-            const emailCell = allVisibleCells.at(1);
-            const createdAtCell = allVisibleCells.at(2);
-            return (
-              <Fragment key={row.id}>
-                <TableRow>
-                  {row.getVisibleCells().map((cell) => {
-                    const attribute = cell.column.columnDef.meta?.attribute;
-                    return (
-                      <TableCell
-                        key={cell.id}
-                        className={cn(
-                          cell.column.id === "expand" ? "text-right" : "",
-                        )}
-                      >
-                        {attribute?.type === "file" &&
-                        row.original[attribute.id] !== null &&
-                        row.original[attribute.id] !== undefined &&
-                        row.original[attribute.id] !== "" ? (
-                          <DownloadAttributeFileButton
-                            attribute={attribute}
-                            eventId={eventId}
-                            participant={row.original}
-                          />
-                        ) : (
-                          flexRender(
-                            cell.column.columnDef.cell,
-                            cell.getContext(),
-                          )
-                        )}
-                      </TableCell>
-                    );
-                  })}
-                </TableRow>
-                {row.getIsExpanded() ? (
-                  /*
-                  TODO Refactor expanded row so it shows only attributes which weren't visible before expanding 
-                   (attribute.showInList = false)
-                   It will require changes in how the edit form will be handled
-                   Use FlattenedParticipant.mode property to render proper UI (editForm/cells)
-                   */
-                  <TableRow
-                    key={`${row.id}-edit`}
-                    className="border-l-primary border-l-2"
-                  >
-                    <TableCell>{null}</TableCell>
-                    <TableCell>
-                      {emailCell === undefined
+      {/* TODO: Prevent resizing width of columns */}
+      <div className="relative w-full overflow-auto">
+        <Table>
+          <TableHeader className="border-border border-b-2">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHead
+                      key={header.id}
+                      className={cn(
+                        "border-border border-r-2",
+                        header.id === "expand" ? "w-16 text-right" : "",
+                      )}
+                    >
+                      {header.isPlaceholder
                         ? null
                         : flexRender(
-                            emailCell.column.columnDef.cell,
-                            emailCell.getContext(),
+                            header.column.columnDef.header,
+                            header.getContext(),
                           )}
-                    </TableCell>
-                    <TableCell>
-                      {createdAtCell === undefined
-                        ? null
-                        : flexRender(
-                            createdAtCell.column.columnDef.cell,
-                            createdAtCell.getContext(),
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.map((row) => {
+              const allVisibleCells = row.getVisibleCells();
+              const attributesCells = allVisibleCells.filter(
+                (cell) => cell.column.columnDef.meta?.attribute !== undefined,
+              );
+              // headers structure - [select, email, createdAt, ...attributes, expand]
+              const emailCell = allVisibleCells.at(1);
+              const createdAtCell = allVisibleCells.at(2);
+              return (
+                <Fragment key={row.id}>
+                  <TableRow>
+                    {row.getVisibleCells().map((cell) => {
+                      const attribute = cell.column.columnDef.meta?.attribute;
+                      return (
+                        <TableCell
+                          key={cell.id}
+                          className={cn(
+                            cell.column.id === "expand" ? "text-right" : "",
                           )}
-                    </TableCell>
-                    <TableCell className="p-0" colSpan={attributesCells.length}>
-                      <EditParticipantForm
-                        cells={attributesCells}
-                        eventId={eventId}
-                        row={row}
-                        setData={setData}
-                      ></EditParticipantForm>
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex w-fit flex-col">
-                        <DeleteParticipantDialog
-                          isQuerying={isQuerying}
-                          participantId={row.original.id}
-                          deleteParticipant={deleteParticipant}
-                        />
-                      </div>
-                    </TableCell>
+                        >
+                          {attribute?.type === "file" &&
+                          row.original[attribute.id] !== null &&
+                          row.original[attribute.id] !== undefined &&
+                          row.original[attribute.id] !== "" ? (
+                            <DownloadAttributeFileButton
+                              attribute={attribute}
+                              eventId={eventId}
+                              participant={row.original}
+                            />
+                          ) : (
+                            flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext(),
+                            )
+                          )}
+                        </TableCell>
+                      );
+                    })}
                   </TableRow>
-                ) : null}
-              </Fragment>
-            );
-          })}
-        </TableBody>
-      </Table>
+                  {row.getIsExpanded() ? (
+                    /*
+                      TODO Refactor expanded row so it shows only attributes which weren't visible before expanding 
+                      (attribute.showInList = false)
+                      It will require changes in how the edit form will be handled
+                      Use FlattenedParticipant.mode property to render proper UI (editForm/cells)
+                    */
+                    <TableRow
+                      key={`${row.id}-edit`}
+                      className="border-l-primary border-l-2"
+                    >
+                      <TableCell>{null}</TableCell>
+                      <TableCell>
+                        {emailCell === undefined
+                          ? null
+                          : flexRender(
+                              emailCell.column.columnDef.cell,
+                              emailCell.getContext(),
+                            )}
+                      </TableCell>
+                      <TableCell>
+                        {createdAtCell === undefined
+                          ? null
+                          : flexRender(
+                              createdAtCell.column.columnDef.cell,
+                              createdAtCell.getContext(),
+                            )}
+                      </TableCell>
+                      <TableCell
+                        className="p-0"
+                        colSpan={attributesCells.length}
+                      >
+                        <EditParticipantForm
+                          cells={attributesCells}
+                          eventId={eventId}
+                          row={row}
+                          setData={setData}
+                        ></EditParticipantForm>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex w-fit flex-col">
+                          <DeleteParticipantDialog
+                            isQuerying={isQuerying}
+                            participantId={row.original.id}
+                            deleteParticipant={deleteParticipant}
+                          />
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ) : null}
+                </Fragment>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
       {table.getRowCount() === 0 ? (
         <div className="text-center">
           Nie znaleziono żadnych pasujących wyników

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -6,13 +6,11 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
-    <table
-      ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
-      {...props}
-    />
-  </div>
+  <table
+    ref={ref}
+    className={cn("w-full caption-bottom text-sm", className)}
+    {...props}
+  />
 ));
 Table.displayName = "Table";
 


### PR DESCRIPTION
Closes #85 

PR zmienia trochę markup komponentu tabeli - defaultowo shadcn narzuca że sam element `<table>` jest wrapowany divem z klasami `<div className="relative w-full overflow-auto">`. Trochę to utrudnia zrobienie automatycznego pionowego overflowu. 

Nie wiem czy jest to najlepsze rozwiązanie tego problemu z overflowem, ale usunąłem to z komponentu tabeli pod `@/components/table.tsx` i teraz trzeba będzie wrapować wg. potrzeby - np. w tej tabeli z historią maila mamy `<div className="relative max-h-48 overflow-y-auto">`. W związku z tą zmianą w komponencie tabeli uczestników dodałem ten sam div co jest defaultowo.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor table component markup by removing default wrapping `div` from `Table` and updating usage in `EmailHistoryTable` and `ParticipantTable`.
> 
>   - **Markup Changes**:
>     - Removed default wrapping `div` with `className="relative w-full overflow-auto"` from `Table` in `table.tsx`.
>     - Updated `EmailHistoryTable` in `emails/(table)/table.tsx` to manually wrap `Table` with `div` having `className="relative max-h-72 overflow-y-auto"`.
>     - Updated `ParticipantTable` in `participants/table/participants-table.tsx` to manually wrap `Table` with `div` having `className="relative w-full overflow-auto"`.
>   - **Comments**:
>     - Fixed typo in comment in `participants-table.tsx` ("//TODO" to "// TODO").
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for 83e6699d7e8561b620edf9cdbc5196581483ed7e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->