### PR TITLE
feat: allow event creation on current day

### DIFF
--- a/src/app/dashboard/(create-event)/(steps)/general-info.tsx
+++ b/src/app/dashboard/(create-event)/(steps)/general-info.tsx
@@ -31,13 +31,9 @@ import { eventAtom } from "../state";
 const EventGeneralInfoSchema = z.object({
   name: z.string().nonempty("Nazwa nie może być pusta."),
   description: z.string().optional(),
-  startDate: z.date().min(subDays(new Date(), 1), {
-    message: "Data rozpoczęcia nie może być w przeszłości.",
-  }),
+  startDate: z.date(),
   startTime: z.string().nonempty("Godzina rozpoczęcia nie może być pusta."),
-  endDate: z.date().refine((date) => date >= subDays(new Date(), 1), {
-    message: "Data zakończenia musi być po dacie rozpoczęcia.",
-  }),
+  endDate: z.date(),
   endTime: z.string().nonempty("Godzina zakończenia nie może być pusta."),
   location: z.string().optional(),
   organizer: z.string().optional(),
@@ -154,7 +150,9 @@ export function GeneralInfoForm({
                               mode="single"
                               selected={field.value}
                               onSelect={field.onChange}
-                              disabled={(date) => date <= new Date()}
+                              disabled={(date) =>
+                                date <= subDays(new Date(), 1)
+                              }
                             />
                           </PopoverContent>
                         </Popover>
@@ -214,7 +212,7 @@ export function GeneralInfoForm({
                                 date <
                                 // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
                                 (form.getValues("startDate") === undefined
-                                  ? new Date()
+                                  ? subDays(new Date(), 1)
                                   : form.getValues("startDate"))
                               }
                             />

--- a/src/app/dashboard/(create-event)/(steps)/general-info.tsx
+++ b/src/app/dashboard/(create-event)/(steps)/general-info.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { format, getHours, getMinutes } from "date-fns";
+import { format, getHours, getMinutes, subDays } from "date-fns";
 import { useAtom } from "jotai";
 import { ArrowRight, CalendarIcon, Loader2 } from "lucide-react";
 import { useForm } from "react-hook-form";
@@ -31,11 +31,11 @@ import { eventAtom } from "../state";
 const EventGeneralInfoSchema = z.object({
   name: z.string().nonempty("Nazwa nie może być pusta."),
   description: z.string().optional(),
-  startDate: z.date().min(new Date(), {
-    message: "Data musi być w przyszłości.",
+  startDate: z.date().min(subDays(new Date(), 1), {
+    message: "Data rozpoczęcia nie może być w przeszłości.",
   }),
   startTime: z.string().nonempty("Godzina rozpoczęcia nie może być pusta."),
-  endDate: z.date().refine((date) => date > new Date(), {
+  endDate: z.date().refine((date) => date >= subDays(new Date(), 1), {
     message: "Data zakończenia musi być po dacie rozpoczęcia.",
   }),
   endTime: z.string().nonempty("Godzina zakończenia nie może być pusta."),
@@ -70,6 +70,18 @@ export function GeneralInfoForm({
     );
     values.endDate.setHours(Number.parseInt(values.endTime.split(":")[0]));
     values.endDate.setMinutes(Number.parseInt(values.endTime.split(":")[1]));
+    if (values.startDate < new Date()) {
+      form.setError("startDate", {
+        message: "Data rozpoczęcia nie może być w przeszłości.",
+      });
+      return;
+    }
+    if (values.endDate < values.startDate) {
+      form.setError("endDate", {
+        message: "Data zakończenia musi być po dacie rozpoczęcia.",
+      });
+      return;
+    }
     setEvent({
       ...event,
       name: values.name,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Allows event creation on the current day by updating date validation and UI logic in `general-info.tsx`.
> 
>   - **Behavior**:
>     - Allows event creation on the current day by removing `.min(new Date())` constraint from `startDate` and `endDate` in `EventGeneralInfoSchema`.
>     - Adjusts date validation in `onSubmit()` to allow current day for `startDate` and ensure `endDate` is after `startDate`.
>   - **UI**:
>     - Updates `Calendar` component in `GeneralInfoForm` to disable dates before the current day using `subDays(new Date(), 1)`.
>     - Ensures `endDate` cannot be before `startDate` in the `Calendar` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for d61cff648ed78d3d5f3a02a515a1d05abd194613. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->