### PR TITLE
fix: change event publicShow urls

### DIFF
--- a/src/app/[eventSlug]/[formSlug]/[userId]/page.tsx
+++ b/src/app/[eventSlug]/[formSlug]/[userId]/page.tsx
@@ -22,7 +22,7 @@ interface FormPageProps {
 }
 
 async function getEvent(eventSlug: string) {
-  const eventResponse = await fetch(`${API_URL}/events/${eventSlug}`, {
+  const eventResponse = await fetch(`${API_URL}/events/${eventSlug}/public`, {
     method: "GET",
   });
   if (!eventResponse.ok) {

--- a/src/app/[eventSlug]/page.tsx
+++ b/src/app/[eventSlug]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({
 }: EventPageProps): Promise<Metadata> {
   const { eventSlug } = await params;
 
-  const response = await fetch(`${API_URL}/events/${eventSlug}`, {
+  const response = await fetch(`${API_URL}/events/${eventSlug}/public`, {
     method: "GET",
   });
   if (!response.ok) {
@@ -46,7 +46,7 @@ export async function generateMetadata({
 
 export default async function EventPage({ params }: EventPageProps) {
   const { eventSlug } = await params;
-  const response = await fetch(`${API_URL}/events/${eventSlug}`, {
+  const response = await fetch(`${API_URL}/events/${eventSlug}/public`, {
     method: "GET",
   });
   if (!response.ok) {

--- a/src/app/dashboard/(create-event)/actions.ts
+++ b/src/app/dashboard/(create-event)/actions.ts
@@ -8,7 +8,7 @@ import { verifySession } from "@/lib/session";
 import type { Event } from "./state";
 
 export async function isSlugTaken(slug: string) {
-  const response = await fetch(`${API_URL}/events/${slug}`);
+  const response = await fetch(`${API_URL}/events/${slug}/public`);
   return response.ok;
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update API endpoint URLs to include '/public' for fetching event data in multiple files.
> 
>   - **Behavior**:
>     - Update API endpoint URLs to include `/public` for fetching event data in `page.tsx` and `actions.ts`.
>     - Affects `getEvent()` in `page.tsx`, `generateMetadata()` and `EventPage()` in `page.tsx`, and `isSlugTaken()` in `actions.ts`.
>   - **Misc**:
>     - No changes to logic or additional features added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for 5d8e55bf855d4c2a261246afb41f755d1d1a6b93. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->