### PR TITLE
fix: show in table checked by default; proper form reset

### DIFF
--- a/src/app/dashboard/(create-event)/(steps)/attributes.tsx
+++ b/src/app/dashboard/(create-event)/(steps)/attributes.tsx
@@ -425,6 +425,7 @@ export function AttributesForm({
         name: "",
         type: "text",
       });
+      form.setFocus("name");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [form.formState.isSubmitSuccessful]);

--- a/src/app/dashboard/(create-event)/(steps)/attributes.tsx
+++ b/src/app/dashboard/(create-event)/(steps)/attributes.tsx
@@ -29,7 +29,7 @@ import {
   TrashIcon,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { memo, useCallback, useState } from "react";
+import { memo, useCallback, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -110,7 +110,7 @@ const SortableOption = memo(({ option, onRemove }: SortableOptionProps) => {
 });
 SortableOption.displayName = "SortableOption";
 
-const attributeTypeOptions = () =>
+const AttributeTypeOptions = () =>
   ATTRIBUTE_TYPES.map((type) => (
     <SelectItem key={type.value} value={type.value}>
       <div className="flex items-center gap-2">
@@ -217,7 +217,9 @@ const AttributeItem = memo(
               <SelectTrigger className="w-[180px]">
                 <SelectValue placeholder="Type" />
               </SelectTrigger>
-              <SelectContent>{attributeTypeOptions()}</SelectContent>
+              <SelectContent>
+                <AttributeTypeOptions />
+              </SelectContent>
             </Select>
 
             <div className="flex flex-col gap-2">
@@ -247,6 +249,7 @@ const AttributeItem = memo(
                 onCheckedChange={(checked) => {
                   onUpdate({ ...attribute, showInList: checked === true });
                 }}
+                defaultChecked={true}
               />
               <Label htmlFor={`showInTable-${attribute.id.toString()}`}>
                 Pokaż w tabeli
@@ -337,13 +340,12 @@ export function AttributesForm({
           eventId: 0,
           options: [],
           rootBlockId: undefined,
-          showInList: false,
+          showInList: true,
           createdAt: "", // set it to empty string to avoid type error
           updatedAt: "", // set it to empty string to avoid type error
         },
       ],
     }));
-    form.reset();
   }
 
   const handleUpdateAttribute = useCallback(
@@ -417,6 +419,16 @@ export function AttributesForm({
     setLoading(false);
   }
 
+  useEffect(() => {
+    if (form.formState.isSubmitSuccessful) {
+      form.reset({
+        name: "",
+        type: "text",
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form.formState.isSubmitSuccessful]);
+
   return (
     <FormContainer
       step="4/4"
@@ -467,7 +479,7 @@ export function AttributesForm({
                       <FormItem className="space-y-0">
                         <Select
                           onValueChange={field.onChange}
-                          defaultValue={field.value}
+                          value={field.value}
                         >
                           <FormControl>
                             <SelectTrigger
@@ -478,7 +490,7 @@ export function AttributesForm({
                             </SelectTrigger>
                           </FormControl>
                           <SelectContent>
-                            {attributeTypeOptions()}
+                            <AttributeTypeOptions />
                           </SelectContent>
                         </Select>
                       </FormItem>


### PR DESCRIPTION
## Fixy
- Każdy nowo dodany atrybut jest też teraz domyślnie widoczny w tabeli (`showInList: true,` w default values).
- Select z typem atrybutu już się poprawnie resetuje. Powodem tego że nie działało był fakt że Select miał prop `defaultValue` zamiast `value`. Nie wiem czemu w docsach shadcn'a jest `defaultValue` zamiast `value`, bo bez tego ten Select nie jest tak właściwie controlled komponentem. Przez to ten Select mógł zmieniać "wewnętrzny" stan forma ale go wizualnie nie odwzierciedlał - np. w przypadku gdy się dodało atrybut typu "Czas" a następnie dodano kolejny atrybut bez ruszania tego selecta, to dodałby się atrybut typu tekst, bo form się poprawnie zresetował ale select tego nie odzwierciedlił.
- Input z nazwą atrybutu jest teraz autofocusowany po każdym dodaniu nowego. Dziwny błąd bo na firefoxie się nie dział ale na chromium już tak.
## Refaktory
- `AttributeTypeOptions` to teraz właściwy komponent dzięki PascalCase'owi, nie wiem czemu wcześniej to było jako funkcja.
- Form jest teraz resetowany wg. zaleceń w [docsach react hook forma (sekcja rules)](https://react-hook-form.com/docs/useform/reset)