### PR TITLE
(Participants table) Change search behaviour to be more intuitive

### DIFF
--- a/src/app/dashboard/events/[id]/participants/table/table-menu.tsx
+++ b/src/app/dashboard/events/[id]/participants/table/table-menu.tsx
@@ -1,5 +1,6 @@
 import type { Table } from "@tanstack/react-table";
 import { ArrowUpDown, ChevronLeft, ChevronRight, FilterX } from "lucide-react";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -35,6 +36,11 @@ export function TableMenu({
   isQuerying: boolean;
   deleteManyParticipants: (_participants: string[]) => Promise<void>;
 }) {
+  // allows for coming back to the page where user started typing in searchbox
+  const [pageBeforeSearch, setPageBeforeSearch] = useState(
+    table.getState().pagination.pageIndex,
+  );
+
   return (
     <div className="flex w-full flex-wrap items-center justify-between gap-x-2">
       <div className="flex items-center gap-x-2">
@@ -43,7 +49,17 @@ export function TableMenu({
           placeholder="Wyszukaj..."
           value={globalFilter}
           onChange={(event) => {
-            table.setGlobalFilter(String(event.target.value));
+            const searchValue = event.target.value;
+            table.setGlobalFilter(searchValue);
+
+            if (
+              pageBeforeSearch > 0 &&
+              table.getState().pagination.pageIndex > 0
+            ) {
+              table.firstPage();
+            } else if (searchValue === "") {
+              table.setPageIndex(pageBeforeSearch);
+            }
           }}
         ></Input>
         <Button
@@ -115,6 +131,9 @@ export function TableMenu({
             disabled={!table.getCanPreviousPage()}
             onClick={() => {
               table.previousPage();
+              setPageBeforeSearch((previous) => {
+                return previous - 1;
+              });
             }}
           >
             <ChevronLeft />
@@ -125,6 +144,9 @@ export function TableMenu({
             disabled={!table.getCanNextPage()}
             onClick={() => {
               table.nextPage();
+              setPageBeforeSearch((previous) => {
+                return previous + 1;
+              });
             }}
           >
             <ChevronRight />

--- a/src/app/dashboard/events/[id]/participants/table/table-menu.tsx
+++ b/src/app/dashboard/events/[id]/participants/table/table-menu.tsx
@@ -40,6 +40,7 @@ export function TableMenu({
   const [pageBeforeSearch, setPageBeforeSearch] = useState(
     table.getState().pagination.pageIndex,
   );
+  const [isUserSearching, setIsUserSearching] = useState(false);
 
   return (
     <div className="flex w-full flex-wrap items-center justify-between gap-x-2">
@@ -49,6 +50,7 @@ export function TableMenu({
           placeholder="Wyszukaj..."
           value={globalFilter}
           onChange={(event) => {
+            setIsUserSearching(true);
             const searchValue = event.target.value;
             table.setGlobalFilter(searchValue);
 
@@ -59,6 +61,7 @@ export function TableMenu({
               table.firstPage();
             } else if (searchValue === "") {
               table.setPageIndex(pageBeforeSearch);
+              setIsUserSearching(false);
             }
           }}
         ></Input>
@@ -131,9 +134,11 @@ export function TableMenu({
             disabled={!table.getCanPreviousPage()}
             onClick={() => {
               table.previousPage();
-              setPageBeforeSearch((previous) => {
-                return previous - 1;
-              });
+              if (!isUserSearching) {
+                setPageBeforeSearch((previous) => {
+                  return previous - 1;
+                });
+              }
             }}
           >
             <ChevronLeft />
@@ -144,9 +149,11 @@ export function TableMenu({
             disabled={!table.getCanNextPage()}
             onClick={() => {
               table.nextPage();
-              setPageBeforeSearch((previous) => {
-                return previous + 1;
-              });
+              if (!isUserSearching) {
+                setPageBeforeSearch((previous) => {
+                  return previous + 1;
+                });
+              }
             }}
           >
             <ChevronRight />


### PR DESCRIPTION
# Fix

Teraz gdy użytkownik zacznie pisać w searchboxie, to tabela wraca do pierwszej strony, aby pokazywać znalezione wyniki. Gdy użytkownik skasuje wartość w searchboxie (`value = ""`), tabela wyświetla dane ze strony przed wyszukiwaniem - [patrz](https://github.com/Solvro/web-eventownik-v2/pull/154/files#diff-249fbc28c9d35d03601ff1bb5bbecfbe25655ee748b2ae75e402c039342f4931R55-R61)

Resolves #149 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves search behavior in `TableMenu` by resetting to the first page on search and returning to the previous page when search is cleared.
> 
>   - **Behavior**:
>     - Search in `TableMenu` resets table to first page when initiated.
>     - Clears search (`value = ""`) returns table to page before search.
>   - **State Management**:
>     - Adds `pageBeforeSearch` and `isUserSearching` state variables in `TableMenu` to track pagination state during search.
>   - **Pagination**:
>     - Updates pagination buttons to adjust `pageBeforeSearch` when navigating pages if not searching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Solvro%2Fweb-eventownik-v2&utm_source=github&utm_medium=referral)<sup> for 69560f419e1a9f37248f6c75fd57ad9a053c33b4. You can [customize](https://app.ellipsis.dev/Solvro/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->