### PR TITLE
Zmiana wyglądu scrollbarów przy użyciu ScrollArea

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-popover": "^1.1.6",
         "@radix-ui/react-radio-group": "^1.2.3",
+        "@radix-ui/react-scroll-area": "^1.2.10",
         "@radix-ui/react-select": "^2.1.6",
         "@radix-ui/react-separator": "^1.1.3",
         "@radix-ui/react-slot": "^1.1.2",
@@ -2477,6 +2478,108 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-popover": "^1.1.6",
     "@radix-ui/react-radio-group": "^1.2.3",
+    "@radix-ui/react-scroll-area": "^1.2.10",
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-separator": "^1.1.3",
     "@radix-ui/react-slot": "^1.1.2",

--- a/src/app/[eventSlug]/[formSlug]/[userSlug]/actions.ts
+++ b/src/app/[eventSlug]/[formSlug]/[userSlug]/actions.ts
@@ -20,7 +20,7 @@ export async function submitForm(
   values: Values,
   formId: string,
   eventSlug: string,
-  userId: string,
+  userSlug: string,
   files: File[],
 ) {
   try {
@@ -31,7 +31,7 @@ export async function submitForm(
       formData.append(file.name, file);
     }
 
-    formData.append("participantSlug", userId);
+    formData.append("participantSlug", userSlug);
     for (const [key, value] of Object.entries(values)) {
       formData.append(key, String(value));
     }

--- a/src/app/[eventSlug]/[formSlug]/[userSlug]/form-generator.tsx
+++ b/src/app/[eventSlug]/[formSlug]/[userSlug]/form-generator.tsx
@@ -31,14 +31,14 @@ export function FormGenerator({
   originalEventBlocks,
   formId,
   eventSlug,
-  userId,
+  userSlug,
 }: {
   attributes: FormAttribute[];
   userData: PublicParticipant;
   originalEventBlocks: PublicBlock[];
   formId: string;
   eventSlug: string;
-  userId: string;
+  userSlug: string;
 }) {
   const [files, setFiles] = useState<File[]>([]);
   const [eventBlocks, setEventBlocks] = useState(originalEventBlocks);
@@ -68,7 +68,13 @@ export function FormGenerator({
 
   async function onSubmit(values: z.infer<typeof FormSchema>) {
     try {
-      const result = await submitForm(values, formId, eventSlug, userId, files);
+      const result = await submitForm(
+        values,
+        formId,
+        eventSlug,
+        userSlug,
+        files,
+      );
       if (result.success) {
         setFiles([]);
       } else {

--- a/src/app/[eventSlug]/[formSlug]/[userSlug]/page.tsx
+++ b/src/app/[eventSlug]/[formSlug]/[userSlug]/page.tsx
@@ -18,7 +18,7 @@ import type { PublicParticipant } from "@/types/participant";
 import { FormGenerator } from "./form-generator";
 
 interface FormPageProps {
-  params: Promise<{ eventSlug: string; formSlug: string; userId: string }>;
+  params: Promise<{ eventSlug: string; formSlug: string; userSlug: string }>;
 }
 
 async function getEvent(eventSlug: string) {
@@ -53,10 +53,10 @@ async function getForm(eventSlug: string, formSlug: string) {
 async function getUserData(
   formAttributes: FormAttribute[],
   eventSlug: string,
-  userId: string,
+  userSlug: string,
 ) {
   const attributesUrl = new URL(
-    `${API_URL}/events/${eventSlug}/participants/${userId}`,
+    `${API_URL}/events/${eventSlug}/participants/${userSlug}`,
   );
 
   for (const attribute of formAttributes) {
@@ -94,7 +94,7 @@ async function getEventBlockAttributeBlocks(
 }
 
 export default async function FormPage({ params }: FormPageProps) {
-  const { eventSlug, formSlug, userId } = await params;
+  const { eventSlug, formSlug, userSlug } = await params;
 
   const event = await getEvent(eventSlug);
   if (event === null) {
@@ -106,7 +106,7 @@ export default async function FormPage({ params }: FormPageProps) {
     return <div>Nie znaleziono formularza 😪</div>;
   }
 
-  const userData = await getUserData(form.attributes, event.slug, userId);
+  const userData = await getUserData(form.attributes, event.slug, userSlug);
   if (userData === null) {
     return <div>Nie udało się pobrać twoich danych 😪</div>;
   }
@@ -232,7 +232,7 @@ export default async function FormPage({ params }: FormPageProps) {
           originalEventBlocks={eventBlocks as unknown as PublicBlock[]}
           formId={form.id.toString()}
           eventSlug={eventSlug}
-          userId={userId}
+          userSlug={userSlug}
         />
       </div>
     </div>

--- a/src/app/[eventSlug]/[formSlug]/[userSlug]/page.tsx
+++ b/src/app/[eventSlug]/[formSlug]/[userSlug]/page.tsx
@@ -7,7 +7,9 @@ import sanitizeHtml from "sanitize-html";
 import { AddToCalendarButton } from "@/components/add-to-calendar-button";
 import { AppLogo } from "@/components/app-logo";
 import { EventInfoDiv } from "@/components/event-info-div";
+import { EventPrimaryColorSetter } from "@/components/event-primary-color";
 import { SocialMediaLink } from "@/components/social-media-link";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { API_URL, PHOTO_URL } from "@/lib/api";
 import type { FormAttribute } from "@/types/attributes";
 import type { PublicBlock } from "@/types/blocks";
@@ -153,6 +155,7 @@ export default async function FormPage({ params }: FormPageProps) {
 
   return (
     <div className="flex min-h-screen flex-col md:max-h-screen md:flex-row">
+      <EventPrimaryColorSetter primaryColor={event.primaryColor} />
       <div
         className="flex flex-1 flex-col justify-between p-4 text-[#f0f0ff]"
         style={{
@@ -210,14 +213,17 @@ export default async function FormPage({ params }: FormPageProps) {
                   : null}
               </div>
             </div>
-            <div
-              className="max-h-72 overflow-y-auto leading-relaxed whitespace-pre-line [&>h1]:text-2xl [&>h2]:text-xl [&>h3]:text-lg"
-              // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
-            />
+            <ScrollArea className="h-72">
+              <div
+                className="leading-relaxed whitespace-pre-line [&>h1]:text-2xl [&>h2]:text-xl [&>h3]:text-lg"
+                // eslint-disable-next-line react/no-danger
+                dangerouslySetInnerHTML={{ __html: sanitizedDescription }}
+              />
+            </ScrollArea>
           </div>
         </div>
       </div>
+      {/* No need for ScrollArea (it's viewport's side scrollbar) */}
       <div className="relative flex flex-1 flex-col items-center gap-y-2 p-4 md:overflow-y-auto">
         <h2 className="text-center text-3xl font-bold md:text-4xl">
           {form.name}

--- a/src/app/[eventSlug]/page.tsx
+++ b/src/app/[eventSlug]/page.tsx
@@ -9,6 +9,7 @@ import { AppLogo } from "@/components/app-logo";
 import { EventInfoDiv } from "@/components/event-info-div";
 import { EventPrimaryColorSetter } from "@/components/event-primary-color";
 import { SocialMediaLink } from "@/components/social-media-link";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { API_URL, PHOTO_URL } from "@/lib/api";
 import type { Event } from "@/types/event";
 
@@ -118,12 +119,15 @@ export default async function EventPage({ params }: EventPageProps) {
                   : null}
               </div>
             </div>
-            <p className="max-h-72 overflow-y-auto leading-relaxed whitespace-pre-line">
-              {event.description}
-            </p>
+            <ScrollArea className="h-72">
+              <p className="leading-relaxed whitespace-pre-line">
+                {event.description}
+              </p>
+            </ScrollArea>
           </div>
         </div>
       </div>
+      {/* No need for ScrollArea (it's viewport's side scrollbar) */}
       <div className="relative flex flex-1 flex-col items-center gap-y-2 p-4 md:overflow-y-auto">
         <h2 className="text-center text-3xl font-bold md:text-4xl">
           Rejestracja na wydarzenie

--- a/src/app/dashboard/(create-event)/(steps)/coorganizers.tsx
+++ b/src/app/dashboard/(create-event)/(steps)/coorganizers.tsx
@@ -124,7 +124,7 @@ export function CoorganizersForm({
           <p>Współorganizatorzy</p>
           {event.coorganizers.map((coorganizer) => (
             <div
-              key={coorganizer.id}
+              key={coorganizer.email}
               className="flex w-full flex-row items-center justify-between gap-2"
             >
               <p className="border-input file:text-foreground placeholder:text-muted-foreground focus-visible:ring-ring flex h-12 w-full rounded-xl border bg-transparent px-4 py-3 text-lg shadow-xs transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-1 focus-visible:outline-hidden md:text-sm">
@@ -136,7 +136,7 @@ export function CoorganizersForm({
                   setEvent((_event) => ({
                     ..._event,
                     coorganizers: _event.coorganizers.filter(
-                      (co) => co.id !== coorganizer.id,
+                      (co) => co.email !== coorganizer.email,
                     ),
                   }));
                 }}

--- a/src/app/dashboard/events/[id]/blocks/[blockId]/(table)/table.tsx
+++ b/src/app/dashboard/events/[id]/blocks/[blockId]/(table)/table.tsx
@@ -6,7 +6,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 
-import { ScrollArea } from "@/components/ui/scroll-area";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import {
   Table,
   TableBody,
@@ -31,7 +31,7 @@ function BlockParticipantsTable({
   });
 
   return (
-    <ScrollArea className="max-h-72">
+    <ScrollArea className="max-h-72 min-w-0 flex-1">
       <div className="relative">
         <Table>
           <TableHeader>
@@ -79,6 +79,7 @@ function BlockParticipantsTable({
           </TableBody>
         </Table>
       </div>
+      <ScrollBar orientation="horizontal" />
     </ScrollArea>
   );
 }

--- a/src/app/dashboard/events/[id]/blocks/[blockId]/(table)/table.tsx
+++ b/src/app/dashboard/events/[id]/blocks/[blockId]/(table)/table.tsx
@@ -6,6 +6,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Table,
   TableBody,
@@ -30,50 +31,55 @@ function BlockParticipantsTable({
   });
 
   return (
-    <div className="relative max-h-72 overflow-y-auto">
-      <Table>
-        <TableHeader>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id}>
-              {headerGroup.headers.map((header) => {
-                return (
-                  <TableHead key={header.id}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </TableHead>
-                );
-              })}
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody>
-          {table.getRowModel().rows.length > 0 ? (
-            table.getRowModel().rows.map((row) => (
-              <TableRow key={row.id}>
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
+    <ScrollArea className="max-h-72">
+      <div className="relative">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                    </TableHead>
+                  );
+                })}
               </TableRow>
-            ))
-          ) : (
-            <TableRow className="hover:bg-transparent">
-              <TableCell
-                colSpan={columns.length}
-                className="text-muted h-24 text-center"
-              >
-                Ten blok nie ma żadnych uczestników
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-      </Table>
-    </div>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length > 0 ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow className="hover:bg-transparent">
+                <TableCell
+                  colSpan={columns.length}
+                  className="text-muted h-24 text-center"
+                >
+                  Ten blok nie ma żadnych uczestników
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </ScrollArea>
   );
 }
 

--- a/src/app/dashboard/events/[id]/blocks/[blockId]/page.tsx
+++ b/src/app/dashboard/events/[id]/blocks/[blockId]/page.tsx
@@ -54,10 +54,14 @@ async function getParticipantsInRootBlock(
     return [];
   }
   const participants = (await response.json()) as Participant[];
+  // TODO fix case when block attribute has field showInList=false
+  // In such case this filter will return empty list
+  // since participants won't have block attribute in their fields (attribute.id === blockId is always false)
+  // The error results from what data does the backend return (`${API_URL}/events/${eventId}/participants` endpoint)
   return participants.filter((participant) => {
-    const targetBlockAttribute = participant.attributes.find(
-      (attribute) => attribute.id.toString() === blockId,
-    );
+    const targetBlockAttribute = participant.attributes.find((attribute) => {
+      return attribute.id.toString() === blockId;
+    });
     return targetBlockAttribute !== undefined;
   });
 }

--- a/src/app/dashboard/events/[id]/emails/(table)/table.tsx
+++ b/src/app/dashboard/events/[id]/emails/(table)/table.tsx
@@ -6,6 +6,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Table,
   TableBody,
@@ -26,50 +27,55 @@ function EmailHistoryTable({ email }: { email: SingleEventEmail }) {
   });
 
   return (
-    <div className="relative max-h-72 overflow-y-auto">
-      <Table>
-        <TableHeader>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id}>
-              {headerGroup.headers.map((header) => {
-                return (
-                  <TableHead key={header.id}>
-                    {header.isPlaceholder
-                      ? null
-                      : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext(),
-                        )}
-                  </TableHead>
-                );
-              })}
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody>
-          {table.getRowModel().rows.length > 0 ? (
-            table.getRowModel().rows.map((row) => (
-              <TableRow key={row.id}>
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
+    <ScrollArea className="max-h-72">
+      <div className="relative">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => {
+                  return (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext(),
+                          )}
+                    </TableHead>
+                  );
+                })}
               </TableRow>
-            ))
-          ) : (
-            <TableRow>
-              <TableCell
-                colSpan={columns.length}
-                className="text-muted h-24 text-center"
-              >
-                Brak wyników
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
-      </Table>
-    </div>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length > 0 ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="text-muted h-24 text-center"
+                >
+                  Brak wyników
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </ScrollArea>
   );
 }
 

--- a/src/app/dashboard/events/[id]/emails/(table)/table.tsx
+++ b/src/app/dashboard/events/[id]/emails/(table)/table.tsx
@@ -6,7 +6,7 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 
-import { ScrollArea } from "@/components/ui/scroll-area";
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import {
   Table,
   TableBody,
@@ -27,7 +27,7 @@ function EmailHistoryTable({ email }: { email: SingleEventEmail }) {
   });
 
   return (
-    <ScrollArea className="max-h-72">
+    <ScrollArea className="max-h-72 min-w-0 flex-1">
       <div className="relative">
         <Table>
           <TableHeader>
@@ -75,6 +75,7 @@ function EmailHistoryTable({ email }: { email: SingleEventEmail }) {
           </TableBody>
         </Table>
       </div>
+      <ScrollBar orientation="horizontal" />
     </ScrollArea>
   );
 }

--- a/src/app/dashboard/events/[id]/participants/table/participants-table.tsx
+++ b/src/app/dashboard/events/[id]/participants/table/participants-table.tsx
@@ -12,6 +12,7 @@ import {
 } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import {
   Table,
   TableBody,
@@ -206,54 +207,58 @@ export function ParticipantTable({
           deleteManyParticipants={deleteManyParticipants}
         />
       </div>
-      <div className="relative mt-4 w-full overflow-auto">
-        <Table>
-          <TableHeader className="border-border border-b-2">
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow
-                className="[&>th:last-of-type]:sticky [&>th:last-of-type]:right-[-1px] [&>th:last-of-type>button]:backdrop-blur-lg"
-                key={headerGroup.id}
-              >
-                {headerGroup.headers.map((header) => {
-                  return (
-                    <TableHead
-                      key={header.id}
-                      className={cn(
-                        "border-border bg-background border-r-2",
-                        header.id === "expand" ? "w-16 text-right" : "",
-                        header.column.columnDef.meta?.headerClassName,
-                      )}
-                    >
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext(),
-                          )}
-                    </TableHead>
-                  );
-                })}
-              </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {table.getRowModel().rows.map((row) => {
-              return (
-                <TableRowForm
-                  key={row.id}
-                  cells={row.getAllCells()}
-                  eventId={eventId}
-                  row={row}
-                  setData={setData}
-                  deleteParticipant={deleteParticipant}
-                  isQuerying={isQuerying}
-                  blocks={blocks ?? []}
-                ></TableRowForm>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </div>
+      <ScrollArea className="mt-4 w-full">
+        <div className="relative">
+          <Table>
+            <TableHeader className="border-border border-b-2">
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow
+                  className="[&>th:last-of-type]:sticky [&>th:last-of-type]:right-[-1px] [&>th:last-of-type>button]:backdrop-blur-lg"
+                  key={headerGroup.id}
+                >
+                  {headerGroup.headers.map((header) => {
+                    return (
+                      <TableHead
+                        key={header.id}
+                        className={cn(
+                          "border-border bg-background border-r-2",
+                          header.id === "expand" ? "w-16 text-right" : "",
+                          header.column.columnDef.meta?.headerClassName,
+                        )}
+                      >
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext(),
+                            )}
+                      </TableHead>
+                    );
+                  })}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {table.getRowModel().rows.map((row) => {
+                return (
+                  <TableRowForm
+                    key={row.id}
+                    cells={row.getAllCells()}
+                    eventId={eventId}
+                    row={row}
+                    setData={setData}
+                    deleteParticipant={deleteParticipant}
+                    isQuerying={isQuerying}
+                    blocks={blocks ?? []}
+                  ></TableRowForm>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+        <ScrollBar orientation="horizontal" />
+      </ScrollArea>
+
       {table.getRowCount() === 0 ? (
         <div className="text-center">
           Nie znaleziono żadnych pasujących wyników

--- a/src/app/dashboard/events/[id]/participants/table/send-mail-form.tsx
+++ b/src/app/dashboard/events/[id]/participants/table/send-mail-form.tsx
@@ -21,6 +21,7 @@ import {
   FormItem,
   FormMessage,
 } from "@/components/ui/form";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Select,
   SelectContent,
@@ -157,11 +158,14 @@ function SendMailForm({
                   Zamierzasz wysłać tą wiadomość do {targetParticipants.length}{" "}
                   uczestników z następującymi adresami:
                 </h2>
-                <pre className="bg-muted/20 max-h-16 overflow-y-auto rounded-md p-4 whitespace-pre-wrap">
-                  {targetParticipants
-                    .map((participant) => participant.email)
-                    .join("\n")}
-                </pre>
+                <ScrollArea className="h-32">
+                  <pre className="bg-muted/70 rounded-md p-4 whitespace-pre-wrap">
+                    {targetParticipants
+                      .map((participant) => participant.email)
+                      .join("\n")}
+                  </pre>
+                </ScrollArea>
+
                 <div className="flex justify-end">
                   <Button
                     type="submit"

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -11,6 +11,7 @@ import { useEffect } from "react";
 import { cn } from "@/lib/utils";
 
 import { EditorMenuBar } from "./editor-menu-bar";
+import { ScrollArea } from "./ui/scroll-area";
 
 function WysiwygEditor({
   content,
@@ -43,8 +44,7 @@ function WysiwygEditor({
     },
     editorProps: {
       attributes: {
-        class:
-          "pb-4 focus:outline-none cursor-text max-h-[200px] overflow-y-auto leading-relaxed",
+        class: "pb-4 focus:outline-none cursor-text leading-relaxed",
       },
       handleKeyDown: (_, event) => {
         if (event.key === "Enter") {
@@ -70,7 +70,9 @@ function WysiwygEditor({
       )}
     >
       <EditorMenuBar editor={editor} />
-      <EditorContent editor={editor} />
+      <ScrollArea className="h-[200px]">
+        <EditorContent editor={editor} />
+      </ScrollArea>
     </div>
   );
 }

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -11,7 +11,7 @@ import { useEffect } from "react";
 import { cn } from "@/lib/utils";
 
 import { EditorMenuBar } from "./editor-menu-bar";
-import { ScrollArea } from "./ui/scroll-area";
+import { ScrollArea, ScrollBar } from "./ui/scroll-area";
 
 function WysiwygEditor({
   content,
@@ -73,6 +73,7 @@ function WysiwygEditor({
       <EditorMenuBar editor={editor} />
       <ScrollArea className="h-[200px]">
         <EditorContent editor={editor} />
+        <ScrollBar orientation="horizontal" />
       </ScrollArea>
     </div>
   );

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  );
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className,
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="bg-border relative flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  );
+}
+
+export { ScrollArea, ScrollBar };


### PR DESCRIPTION
Resolves #87 

# Zmiany

## Zmiana ścieżki z `/{eventSlug}/{formSlug}/{userId}` na `/{eventSlug}/{formSlug}/{userSlug}`

- do wykonywania requestów na tym page'u używamy sluga usera, a nie Id, więc zmieniłem to, żeby nie było to mylące

## Dodawanie współorganizatorów

- naprawa błędu z kluczami w komponentach
- naprawa błędu usuwania współorganizatora

## Użycie ScrollArea

- użyłem ScrollArea przy komponentach, których scrollbary wyświetlają się nie na brzegu viewportu, a wewnątrz

Przykład:

<img width="929" height="556" alt="image" src="https://github.com/user-attachments/assets/696af6c1-9ae8-4ff9-8aa2-543e268c6841" />
