### PR TITLE
feat: dynamic page titles in dashboard

### DIFF
--- a/src/app/[eventSlug]/[formSlug]/[userSlug]/page.tsx
+++ b/src/app/[eventSlug]/[formSlug]/[userSlug]/page.tsx
@@ -1,5 +1,6 @@
 import { format } from "date-fns";
 import { Building2, Calendar1, CalendarX, MapPin, User } from "lucide-react";
+import type { Metadata } from "next";
 import Link from "next/link";
 import React from "react";
 import sanitizeHtml from "sanitize-html";
@@ -93,6 +94,18 @@ async function getEventBlockAttributeBlocks(
     return null;
   }
   return (await blocksResponse.json()) as PublicBlock[];
+}
+
+export async function generateMetadata({
+  params,
+}: FormPageProps): Promise<Metadata> {
+  const { eventSlug, formSlug } = await params;
+
+  const form = await getForm(eventSlug, formSlug);
+
+  return {
+    title: form === null ? "Formularz" : form.name,
+  };
 }
 
 export default async function FormPage({ params }: FormPageProps) {

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Autentykacja",
+  title: "Uwierzytelnianie",
 };
 
 export default function AuthLayout({

--- a/src/app/dashboard/events/[id]/blocks/[blockId]/page.tsx
+++ b/src/app/dashboard/events/[id]/blocks/[blockId]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 
 import { AddBlockEntry } from "@/app/dashboard/events/[id]/blocks/[blockId]/add-block-entry";
@@ -104,8 +105,31 @@ function getParticipantsInChildBlock(
     const targetBlockAttribute = participant.attributes.find(
       (attribute) => attribute.id.toString() === rootBlockId,
     ) as AttributeBase;
-    return targetBlockAttribute.value === childBlockId.toString();
+    return targetBlockAttribute.value === childBlockId;
   });
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string; blockId: string }>;
+}): Promise<Metadata> {
+  const session = await verifySession();
+  if (session == null) {
+    redirect("/auth/login");
+  }
+  const { bearerToken } = session;
+  const { id: eventId, blockId: rootBlockId } = await params;
+
+  const rootBlockName = await getRootBlockAttributeName(
+    eventId,
+    rootBlockId,
+    bearerToken,
+  );
+
+  return {
+    title: rootBlockName,
+  };
 }
 
 export default async function EventBlockEditPage({

--- a/src/app/dashboard/events/[id]/blocks/page.tsx
+++ b/src/app/dashboard/events/[id]/blocks/page.tsx
@@ -1,4 +1,5 @@
 import { PackageOpenIcon } from "lucide-react";
+import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
@@ -6,6 +7,10 @@ import { Button } from "@/components/ui/button";
 import { API_URL } from "@/lib/api";
 import { verifySession } from "@/lib/session";
 import type { Attribute } from "@/types/attributes";
+
+export const metadata: Metadata = {
+  title: "Bloki",
+};
 
 export default async function DashboardEventBlocksPage({
   params,

--- a/src/app/dashboard/events/[id]/emails/page.tsx
+++ b/src/app/dashboard/events/[id]/emails/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+
 import { CreateEmailTemplateForm } from "./create-email-template-form";
 import {
   getEventAttributes,
@@ -5,6 +7,10 @@ import {
   getEventForms,
 } from "./data-access";
 import { EmailTemplateEntry } from "./template-entry";
+
+export const metadata: Metadata = {
+  title: "Szablony maili",
+};
 
 export default async function DashboardEventEmailTemplatesPage({
   params,

--- a/src/app/dashboard/events/[id]/forms/page.tsx
+++ b/src/app/dashboard/events/[id]/forms/page.tsx
@@ -1,6 +1,12 @@
+import type { Metadata } from "next";
+
 import { CreateEventFormForm } from "./create-event-form-form";
 import { getEventAttributes, getEventForms } from "./data-access";
 import { FormEntry } from "./form-entry";
+
+export const metadata: Metadata = {
+  title: "Formularze",
+};
 
 export default async function DashboardEventFormsPage({
   params,

--- a/src/app/dashboard/events/[id]/participants/page.tsx
+++ b/src/app/dashboard/events/[id]/participants/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { redirect } from "next/navigation";
 
 import { ParticipantTable } from "@/app/dashboard/events/[id]/participants/table/participants-table";
@@ -9,6 +10,10 @@ import {
   getEmails,
   getParticipants,
 } from "./actions";
+
+export const metadata: Metadata = {
+  title: "Uczestnicy",
+};
 
 export default async function DashboardEventParticipantsPage({
   params,

--- a/src/app/dashboard/events/[id]/settings/page.tsx
+++ b/src/app/dashboard/events/[id]/settings/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 
 import { EventSettingsTabs } from "@/app/dashboard/events/[id]/settings/settings-tabs";
@@ -6,6 +7,10 @@ import { verifySession } from "@/lib/session";
 import type { EventAttribute } from "@/types/attributes";
 import type { CoOrganizer } from "@/types/co-organizer";
 import type { Event } from "@/types/event";
+
+export const metadata: Metadata = {
+  title: "Ustawienia",
+};
 
 export default async function DashboardEventSettingsPage({
   params,

--- a/src/app/dashboard/events/page.tsx
+++ b/src/app/dashboard/events/page.tsx
@@ -1,5 +1,6 @@
 import { format } from "date-fns";
 import { AlertCircle, Calendar1, CircleHelpIcon, Users } from "lucide-react";
+import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -13,6 +14,10 @@ import { Button } from "@/components/ui/button";
 import { API_URL, PHOTO_URL } from "@/lib/api";
 import { verifySession } from "@/lib/session";
 import type { Event } from "@/types/event";
+
+export const metadata: Metadata = {
+  title: "Moje wydarzenia",
+};
 
 export default async function EventListPage() {
   const session = await verifySession();

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -5,7 +5,10 @@ import { AuthButton } from "@/components/auth-button";
 import { Navbar } from "@/components/navbar";
 
 export const metadata: Metadata = {
-  title: "Dashboard",
+  title: {
+    template: "%s | Eventownik",
+    default: "Dashboard",
+  },
 };
 
 export default function DashboardLayout({


### PR DESCRIPTION
<img width="1169" height="234" alt="image" src="https://github.com/user-attachments/assets/54c912c0-c3e8-4aaf-ad86-3631cc38300a" />

Dodaje dynamiczne tytuły kart w dashboardzie organizatora oraz na stronie formularza eventu (tego innego niż rejestracyjny)

Closes #177 