### PR TITLE
fix: handle disabled registration form

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -14,6 +14,7 @@
     "registrationSuccess": "Registration successful!",
     "registrationFailed": "Registration failed.\\nTry again later",
     "registrationFailedTitle": "Registration failed",
+    "registrationDisabled": "The organizer has disabled registration on Eventownik",
     "tryAgainLater": "Try again later",
     "serverError": "Server error",
     "noForm": "No registration form for this event.",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -14,6 +14,7 @@
     "registrationSuccess": "Twoja rejestracja przebiegła pomyślnie!",
     "registrationFailed": "Rejestracja na wydarzenie nie powiodła się.\\nSpróbuj ponownie później",
     "registrationFailedTitle": "Rejestracja na wydarzenie nie powiodła się",
+    "registrationDisabled": "Organizator wyłączył zapisy na Eventowniku",
     "tryAgainLater": "Spróbuj ponownie później",
     "serverError": "Błąd serwera",
     "noForm": "Brak formularza rejestracyjnego dla tego wydarzenia.",

--- a/src/app/[eventSlug]/page.tsx
+++ b/src/app/[eventSlug]/page.tsx
@@ -60,23 +60,23 @@ export default async function EventPage({ params }: EventPageProps) {
 
   return (
     <EventPageLayout event={event} description={event.description ?? ""}>
-      {event.firstForm == null ? (
-        <div className="flex w-full justify-center pt-4">
-          <p className="bg-background/10 rounded-lg px-4 py-2 text-center backdrop-blur-sm sm:text-2xl sm:font-semibold">
-            {t("registrationDisabled")}
-          </p>
-        </div>
-      ) : (
+      {(event.firstForm?.isOpen ?? false) ? (
         <div className="flex w-full justify-center pt-4">
           <Link href={`/${event.slug}/register#form`}>
             <Button
               variant="eventDefault"
-              className="text-xl tracking-tight backdrop-blur-sm md:p-6 md:text-2xl pointer-fine:bg-[var(--event-primary-color)]/70"
+              className="text-xl tracking-tight backdrop-blur-sm md:p-6 md:text-2xl pointer-fine:bg-(--event-primary-color)/70"
               style={{ viewTransitionName: "register-button" }}
             >
               {t("registerForThisEvent")}
             </Button>
           </Link>
+        </div>
+      ) : (
+        <div className="flex w-full justify-center pt-4">
+          <p className="bg-background/10 rounded-lg px-4 py-2 text-center backdrop-blur-sm sm:text-2xl sm:font-semibold">
+            {t("registrationDisabled")}
+          </p>
         </div>
       )}
     </EventPageLayout>

--- a/src/app/[eventSlug]/register/page.tsx
+++ b/src/app/[eventSlug]/register/page.tsx
@@ -75,7 +75,7 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
         zgadzasz się na warunki zawarte w<br />
         <Link
           href={`/${event.slug}/privacy`}
-          className="text-[var(--event-primary-color)]/90"
+          className="text-(--event-primary-color)/90"
           target="_blank"
         >
           polityce prywatności
@@ -88,7 +88,7 @@ export default async function RegisterPage({ params }: RegisterPageProps) {
             oraz{" "}
             <Link
               href={event.termsLink}
-              className="text-[var(--event-primary-color)]/90"
+              className="text-(--event-primary-color)/90"
               target="_blank"
             >
               regulaminie

--- a/src/app/[eventSlug]/register/register-participant-form.tsx
+++ b/src/app/[eventSlug]/register/register-participant-form.tsx
@@ -17,6 +17,14 @@ export function RegisterParticipantForm({ event }: { event: Event }) {
     );
   }
 
+  if (!event.firstForm.isOpen) {
+    return (
+      <div>
+        <p className="text-sm text-red-500">{t("registrationDisabled")}</p>
+      </div>
+    );
+  }
+
   return (
     <ParticipantForm
       attributes={event.firstForm.attributes}


### PR DESCRIPTION
Naprawia niepokazywanie się komunikatu "Organizator wyłączył zapisy na Eventowniku" w przypadku gdy formularz rejestracyjny istnieje, ale mimo tego jest wyłączony (isOpen = false)

Przetestowane przypadki i komunikaty (zarówno na "landing page'u" wydarzenia jak i na ścieżce "/register")
- Brak formularza rejestracyjnego => "Organizator wyłączył zapisy na Eventowniku" (landing) i "Brak formularza rejestracyjnego" ("/register")
- Formularz rejestracyjny istnieje, włączony => "Zapisz się na wydarzenie" (oba miejsca)
- Formularz rejestracyjny istnieje, wyłączony => "Organizator wyłączył [...]" (oba miejsca)

Wszystkie działają poprawnie