### PR TITLE
fix: remove polish symbols from slug while creating the event;

### DIFF
--- a/src/app/dashboard/(create-event)/create-event-form.tsx
+++ b/src/app/dashboard/(create-event)/create-event-form.tsx
@@ -48,7 +48,7 @@ import { UnsavedChangesAlert } from "@/components/unsaved-changes-alert";
 import { useAutoSave } from "@/hooks/use-autosave";
 import { toast } from "@/hooks/use-toast";
 import { useUnsavedAtom } from "@/hooks/use-unsaved";
-import { cn, getBase64FromUrl } from "@/lib/utils";
+import { cn, getBase64FromUrl, nameToSlug } from "@/lib/utils";
 
 import { isSlugTaken, saveEvent } from "./actions";
 import { eventAtom } from "./state";
@@ -106,10 +106,7 @@ export function CreateEventForm() {
       primaryColor: event.primaryColor,
       participantsNumber: event.participantsNumber,
       socialMediaLinks: event.socialMediaLinks,
-      slug:
-        event.slug === ""
-          ? event.name.toLowerCase().replaceAll(/\s+/g, "-")
-          : event.slug,
+      slug: event.slug === "" ? nameToSlug(event.name) : event.slug,
       contactEmail: event.contactEmail,
       coorganizers: [],
       attributes: [],
@@ -133,9 +130,7 @@ export function CreateEventForm() {
         const currentSlug = form.getValues("slug");
         form.setValue(
           "slug",
-          currentSlug === ""
-            ? values.name.toLowerCase().replaceAll(/\s+/g, "-")
-            : currentSlug,
+          currentSlug === "" ? nameToSlug(values.name) : currentSlug,
         );
         setCurrentStep((value) => value + 1);
       },

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,6 +13,32 @@ const PHONE_REGEX = /\(?([0-9]{3})\)?([ .-]?)([0-9]{3})\2([0-9]{3})/;
 
 export const SLUG_REGEX = /^[a-z0-9-]+$/;
 
+const POLISH_TO_ASCII: Record<string, string> = {
+  ą: "a",
+  ę: "e",
+  ó: "o",
+  ś: "s",
+  ć: "c",
+  ź: "z",
+  ż: "z",
+  ł: "l",
+  ń: "n",
+};
+
+/** Converts a name to a slug compatible with SLUG_REGEX (a-z, 0-9, hyphens). */
+export function nameToSlug(name: string): string {
+  const withAscii = name.replace(
+    /[ąćęłńóśźż]/gi,
+    (char) => POLISH_TO_ASCII[char.toLowerCase()] ?? char,
+  );
+  return withAscii
+    .toLowerCase()
+    .replaceAll(/\s+/g, "-")
+    .replaceAll(/[^a-z0-9-]/g, "")
+    .replaceAll(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
 // Helper function for string validation
 const requiredString = (attribute: FormAttribute) =>
   z


### PR DESCRIPTION
Add function `nameToSlug` to remove polish symbols from slug