### PR TITLE
docs: update favicon image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/Solvro/web-testownik/blob/main/public/favicon/192x192.png?raw=true" width="24"> Eventownik Solvro – Frontend
+# <img src="https://github.com/Solvro/web-testownik/blob/main/public/favicon/180x180.png?raw=true" width="24"> Eventownik Solvro – Frontend
 
 <div align="center">
 


### PR DESCRIPTION
Zaktualizowano favicon w README, ponieważ poprzednia wersja odwoływała się do nieistniejącego pliku.