### PR TITLE
fix: team section width

### DIFF
--- a/src/app/(homepage)/sections/team/index.tsx
+++ b/src/app/(homepage)/sections/team/index.tsx
@@ -290,9 +290,9 @@ export async function Team() {
   return (
     <section
       id="team"
-      className="border-input container mb-16 flex flex-col items-center gap-8 rounded-b-4xl border-x border-b border-dashed bg-radial from-[#366CC8]/50 to-transparent px-8 pt-20 pb-12 sm:gap-24 sm:pb-20"
+      className="border-input container mb-16 flex flex-col items-center gap-8 rounded-b-4xl border-x border-b border-dashed bg-radial from-[#366CC8]/50 to-transparent px-8 pt-20 pb-12 max-sm:overflow-hidden sm:gap-24 sm:pb-20"
     >
-      <div className="flex flex-col items-center gap-8 overflow-hidden">
+      <div className="flex flex-col items-center gap-8">
         <p className="w-min rounded-full border border-[#6583C8] px-5 py-2 text-xl font-medium whitespace-nowrap text-[#6583C8]">
           Solvro Team
         </p>

--- a/src/app/(homepage)/sections/team/index.tsx
+++ b/src/app/(homepage)/sections/team/index.tsx
@@ -292,7 +292,7 @@ export async function Team() {
       id="team"
       className="border-input container mb-16 flex flex-col items-center gap-8 rounded-b-4xl border-x border-b border-dashed bg-radial from-[#366CC8]/50 to-transparent px-8 pt-20 pb-12 sm:gap-24 sm:pb-20"
     >
-      <div className="flex flex-col items-center gap-8">
+      <div className="flex flex-col items-center gap-8 overflow-hidden">
         <p className="w-min rounded-full border border-[#6583C8] px-5 py-2 text-xl font-medium whitespace-nowrap text-[#6583C8]">
           Solvro Team
         </p>


### PR DESCRIPTION
Close #372 
Problem polegał na `-space-x-4` (dla `<Member />` listy) a `flex-wrap` nie działał ponieważ nic się nie wczytywało, a szerokość każdego `div` była 0, więc pozostawało to w jednej linijce, próbowałem ograniczyć to z `max-width`, ale nic. Dodałem `overflow-hidden` do `div` który obejmuje od razu wszystko, bo te bliższe do `<Member />` ucinały zdjęcia.
Też sprawdziłem czy na innych szerokościach nic nie ucina i nie znika, niby git.