### PR TITLE
fix(homepage): handle empty event description rendering

### DIFF
--- a/src/app/(homepage)/sections/events/event-list.tsx
+++ b/src/app/(homepage)/sections/events/event-list.tsx
@@ -112,7 +112,7 @@ function Event({
         <div className="relative flex h-full w-full flex-row items-center gap-16">
           <div className="flex w-full flex-row gap-16">
             {/* Desktop view only */}
-            <div className="hidden w-64 flex-col items-center gap-4 xl:flex">
+            <div className="hidden w-74 flex-col items-center gap-4 xl:flex">
               <p className="text-center text-4xl font-extrabold text-[#274276] dark:text-[#4473E1]">
                 {renderDate()}
               </p>
@@ -120,13 +120,18 @@ function Event({
                 {getEventStatus().status}
               </p>
             </div>
-            <div className="flex flex-col gap-12 xl:w-[calc(100%-40rem)] 2xl:w-[calc(100%-48rem)]">
+            <div className="flex w-full flex-col gap-12 xl:w-[calc(100%-40rem)] 2xl:w-[calc(100%-48rem)]">
               <div className="w-full space-y-6">
                 <p className="text-4xl font-semibold">{name}</p>
                 <p className="text-sm font-medium">{organizer}</p>
-                <ScrollArea className="h-38 pr-3 sm:text-justify">
-                  <SanitizedContent contentToSanitize={description ?? ""} />
-                </ScrollArea>
+                {description === null ||
+                /^<p>\s*<\/p>$/.test(description.trim()) ? (
+                  <div className="xl:h-38" />
+                ) : (
+                  <ScrollArea className="h-38 pr-3 sm:text-justify">
+                    <SanitizedContent contentToSanitize={description} />
+                  </ScrollArea>
+                )}
               </div>
               <Button
                 asChild

--- a/src/app/(homepage)/sections/events/event-list.tsx
+++ b/src/app/(homepage)/sections/events/event-list.tsx
@@ -120,7 +120,7 @@ function Event({
                 {getEventStatus().status}
               </p>
             </div>
-            <div className="flex w-full flex-col gap-12 xl:w-[calc(100%-40rem)] 2xl:w-[calc(100%-48rem)]">
+            <div className="flex w-full flex-col gap-12 xl:w-[calc(100%-42rem)] 2xl:w-[calc(100%-50rem)]">
               <div className="w-full space-y-6">
                 <p className="text-4xl font-semibold">{name}</p>
                 <p className="text-sm font-medium">{organizer}</p>


### PR DESCRIPTION
Problem był podobny jak w przypadku opisów formularzy i szablonów maili. 
Domyślnie pusty opis zawsze miał postać `<p></p>`, co nie było uwzględnione i powodowało powstawanie dużej ilości pustego miejsca na komórce.

Dodatkowo pozostawiono stałą wysokość (`h-38`) dla `ScrollArea`, ponieważ zamiana na `max-h-38` powodowała, że scrollbar przestawał działać poprawnie.