### PR TITLE
feat: translate event description

### DIFF
--- a/src/app/[eventSlug]/privacy/page.tsx
+++ b/src/app/[eventSlug]/privacy/page.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 import { EventNotFound } from "@/app/[eventSlug]/event-not-found";
 import { API_URL, PHOTO_URL } from "@/lib/api";
-import { getAttributeLabel } from "@/lib/utils";
+import { legacyTranslate } from "@/lib/utils";
 import type { Event } from "@/types/event";
 
 import { EventPageLayout } from "../event-page-layout";
@@ -109,7 +109,7 @@ export default async function EventPage({ params }: EventPageProps) {
               {event.attributes.map((attribute) => {
                 return (
                   <li key={attribute.id}>
-                    {getAttributeLabel(attribute.name, "pl")}
+                    {legacyTranslate(attribute.name, "pl")}
                     {attribute.isSensitiveData
                       ? ` (Wyrażam zgodę na przetwarzanie tej informacji w celu: '${attribute.reason ?? "nie podano"}')`
                       : ""}

--- a/src/app/dashboard/events/[id]/participants/table/components/table-ui/column-settings-dropdown.tsx
+++ b/src/app/dashboard/events/[id]/participants/table/components/table-ui/column-settings-dropdown.tsx
@@ -25,7 +25,7 @@ import {
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
 } from "@/components/ui/dropdown-menu";
-import { getAttributeLabel } from "@/lib/utils";
+import { legacyTranslate } from "@/lib/utils";
 import type { FlattenedParticipant } from "@/types/participant";
 
 interface ColumnVisibilityDropdownProps {
@@ -69,7 +69,7 @@ function SortableColumnItem({ column, locale }: SortableColumnItemProps) {
           e.preventDefault();
         }}
       >
-        {getAttributeLabel(column.columnDef.meta?.name ?? column.id, locale)}
+        {legacyTranslate(column.columnDef.meta?.name ?? column.id, locale)}
       </DropdownMenuCheckboxItem>
       <GripVertical
         size={18}

--- a/src/app/dashboard/events/[id]/participants/table/core/columns.tsx
+++ b/src/app/dashboard/events/[id]/participants/table/core/columns.tsx
@@ -3,7 +3,7 @@ import { createColumnHelper } from "@tanstack/react-table";
 import type { useTranslations as UseTranslations } from "next-intl";
 
 import { Checkbox } from "@/components/ui/checkbox";
-import { getAttributeLabel } from "@/lib/utils";
+import { legacyTranslate } from "@/lib/utils";
 import type { Attribute } from "@/types/attributes";
 import type { Block } from "@/types/blocks";
 import type {
@@ -147,7 +147,7 @@ export function createColumns(
             <div className="min-w-0 flex-1">
               <SortHeader
                 info={info}
-                name={getAttributeLabel(attribute.name, locale)}
+                name={legacyTranslate(attribute.name, locale)}
                 truncate
               />
             </div>

--- a/src/app/dashboard/events/[id]/participants/table/import-participants/column-mapping-list.tsx
+++ b/src/app/dashboard/events/[id]/participants/table/import-participants/column-mapping-list.tsx
@@ -9,7 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { getAttributeLabel } from "@/lib/utils";
+import { legacyTranslate } from "@/lib/utils";
 import type { Attribute } from "@/types/attributes";
 
 import { EMAIL_TARGET, SKIP_TARGET } from "./types";
@@ -75,7 +75,7 @@ export function ColumnMappingList({
                         key={attribute.id}
                         value={getAttributeTarget(attribute.id)}
                       >
-                        {getAttributeLabel(attribute.name, locale)}
+                        {legacyTranslate(attribute.name, locale)}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/src/app/dashboard/events/[id]/participants/table/import-participants/mapping.ts
+++ b/src/app/dashboard/events/[id]/participants/table/import-participants/mapping.ts
@@ -1,4 +1,4 @@
-import { getAttributeLabel } from "@/lib/utils";
+import { legacyTranslate } from "@/lib/utils";
 import type { Attribute } from "@/types/attributes";
 
 import { EMAIL_TARGET, SKIP_TARGET } from "./types";
@@ -59,8 +59,8 @@ function getMatchKey(value: string) {
 function getAttributeMatchKeys(attribute: Attribute) {
   const keys = new Set(
     [
-      getAttributeLabel(attribute.name, "pl"),
-      getAttributeLabel(attribute.name, "en"),
+      legacyTranslate(attribute.name, "pl"),
+      legacyTranslate(attribute.name, "en"),
       attribute.slug ?? "",
     ]
       .filter((value) => value !== "")

--- a/src/app/dashboard/events/[id]/participants/table/import-participants/validation.ts
+++ b/src/app/dashboard/events/[id]/participants/table/import-participants/validation.ts
@@ -1,4 +1,4 @@
-import { getAttributeLabel, getSchemaObjectForAttribute } from "@/lib/utils";
+import { getSchemaObjectForAttribute, legacyTranslate } from "@/lib/utils";
 import type { Attribute, AttributeOption } from "@/types/attributes";
 import type { Block } from "@/types/blocks";
 
@@ -71,7 +71,7 @@ function getTargetLabel(
 
   const attributeId = Number(target.replace("attr:", ""));
   const attribute = attributes.find((item) => item.id === attributeId);
-  return attribute == null ? target : getAttributeLabel(attribute.name, locale);
+  return attribute == null ? target : legacyTranslate(attribute.name, locale);
 }
 
 function getSharedValidationError(
@@ -341,7 +341,7 @@ export function prepareImport({
       if (attribute.isRequired && rawValue.trim() === "") {
         issues.push({
           rowIndex,
-          field: getAttributeLabel(attribute.name, locale),
+          field: legacyTranslate(attribute.name, locale),
           message: "validation.required",
         });
         continue;
@@ -351,7 +351,7 @@ export function prepareImport({
       if ("error" in result) {
         issues.push({
           rowIndex,
-          field: getAttributeLabel(attribute.name, locale),
+          field: legacyTranslate(attribute.name, locale),
           message: result.error,
           values: result.values,
         });

--- a/src/components/attribute-input.tsx
+++ b/src/components/attribute-input.tsx
@@ -13,7 +13,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { getAttributeLabel } from "@/lib/utils";
+import { legacyTranslate } from "@/lib/utils";
 import type { FormAttribute } from "@/types/attributes";
 import type { PublicBlock } from "@/types/blocks";
 import type { PublicParticipant } from "@/types/participant";
@@ -62,7 +62,7 @@ export function AttributeInput({
           <SelectTrigger id={attribute.id.toString()}>
             <SelectValue
               placeholder={t("selectAttribute", {
-                name: getAttributeLabel(attribute.name, locale).toLowerCase(),
+                name: legacyTranslate(attribute.name, locale).toLowerCase(),
               })}
             />
           </SelectTrigger>

--- a/src/components/participant-form.tsx
+++ b/src/components/participant-form.tsx
@@ -30,11 +30,7 @@ import {
 } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
 import { translateOrFallback } from "@/i18n/translate-or-fallback";
-import {
-  cn,
-  getAttributeLabel,
-  getSchemaObjectForAttributes,
-} from "@/lib/utils";
+import { cn, getSchemaObjectForAttributes, legacyTranslate } from "@/lib/utils";
 import type { FormValidationErrors } from "@/lib/utils";
 import type { FormAttribute } from "@/types/attributes";
 import type { PublicBlock } from "@/types/blocks";
@@ -340,7 +336,7 @@ export function ParticipantForm({
                   )}
                 >
                   <FormLabel htmlFor={attribute.id.toString()}>
-                    {getAttributeLabel(attribute.name, locale)}{" "}
+                    {legacyTranslate(attribute.name, locale)}{" "}
                     {attribute.isRequired ? (
                       <Tooltip>
                         <TooltipTrigger type="button">
@@ -397,7 +393,7 @@ export function ParticipantForm({
                       // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-member-access
                       (form.formState.errors as any)[attribute.id.toString()]
                         ?.message as FormValidationErrors,
-                      { name: getAttributeLabel(attribute.name, "pl") },
+                      { name: legacyTranslate(attribute.name, "pl") },
                     )}
                   </FormMessage>
                 </FormItem>

--- a/src/components/sanitized-content.tsx
+++ b/src/components/sanitized-content.tsx
@@ -1,14 +1,17 @@
+import { getLocale } from "next-intl/server";
 import sanitizeHtml from "sanitize-html";
 
-import { cn } from "@/lib/utils";
+import { cn, legacyTranslate } from "@/lib/utils";
 
-function SanitizedContent({
+async function SanitizedContent({
   contentToSanitize,
   className,
 }: {
   contentToSanitize: string;
   className?: string;
 }) {
+  const locale = await getLocale();
+
   const sanitized = sanitizeHtml(contentToSanitize, {
     allowedAttributes: {
       a: ["href", "name", "target"],
@@ -32,11 +35,15 @@ function SanitizedContent({
     allowedSchemes: ["data", "https"],
   });
 
+  // TODO: Refactor this once we get proper user-provided values translations
+  // An event description is always contained within a paragraph, `.slice(3, -4)` removes its tags
+  const translated = legacyTranslate(sanitized.slice(3, -4), locale);
+
   return (
     <div
       className={cn("leading-relaxed whitespace-pre-line", className)}
       // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: sanitized }}
+      dangerouslySetInnerHTML={{ __html: translated }}
     />
   );
 }

--- a/src/lib/message-tags/tag-builders.ts
+++ b/src/lib/message-tags/tag-builders.ts
@@ -4,7 +4,7 @@ import { EventAttribute } from "@/types/attributes";
 import { EventForm } from "@/types/forms";
 
 import { MessageTag } from ".";
-import { getAttributeLabel } from "../utils";
+import { legacyTranslate } from "../utils";
 import { getCategories } from "./categories";
 
 export function getAttributeTags(
@@ -14,9 +14,9 @@ export function getAttributeTags(
   const categories = getCategories(t);
 
   return eventAttributes.map((attribute) => ({
-    title: getAttributeLabel(attribute.name, "pl"),
+    title: legacyTranslate(attribute.name, "pl"),
     description: t("attributeItemDesc", {
-      name: getAttributeLabel(attribute.name, "pl"),
+      name: legacyTranslate(attribute.name, "pl"),
     }),
     // NOTE: Why 'attribute.slug' can be null?
     value: `/participant_${attribute.slug ?? ""}`,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -151,12 +151,18 @@ export function downloadFile(blob: Blob, fileName: string) {
   URL.revokeObjectURL(url);
 }
 
-export function getAttributeLabel(name: string, language: string) {
+/**
+ * Parses a JSON string matching `{"pl": "text", "en": "text"}` format
+ * @param value JSON string
+ * @param language Locale key - either "pl" or "en"
+ * @returns The text matching the locale. If not found - the `pl` text. If that wasn't found either - the first key's value. Otherwise - the original string
+ */
+export function legacyTranslate(value: string, language: string) {
   try {
-    const parsed = JSON.parse(name) as Record<string, string>;
+    const parsed = JSON.parse(value) as Record<string, string>;
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    return parsed[language] ?? parsed.pl ?? Object.values(parsed)[0] ?? name;
+    return parsed[language] ?? parsed.pl ?? Object.values(parsed)[0] ?? value;
   } catch {
-    return name;
+    return value;
   }
 }


### PR DESCRIPTION
Dodaje hacky tłumaczenie (tzn. content w formacie `{"pl": "po polsku", "en": "in english"}`) do opisu wydarzenia. Jako że nie jest to już wykorzystywane tylko do nazw atrybutów to przy okazji poleciał rename funkcji