### PR TITLE
build: make sanitized content a client component

### DIFF
--- a/src/components/sanitized-content.tsx
+++ b/src/components/sanitized-content.tsx
@@ -1,16 +1,18 @@
-import { getLocale } from "next-intl/server";
+"use client";
+
+import { useLocale } from "next-intl";
 import sanitizeHtml from "sanitize-html";
 
 import { cn, legacyTranslate } from "@/lib/utils";
 
-async function SanitizedContent({
+function SanitizedContent({
   contentToSanitize,
   className,
 }: {
   contentToSanitize: string;
   className?: string;
 }) {
-  const locale = await getLocale();
+  const locale = useLocale();
 
   const sanitized = sanitizeHtml(contentToSanitize, {
     allowedAttributes: {


### PR DESCRIPTION
Po dodaniu hacky tłumaczeń nie zorientowałem się że wówczas server side SanitizedContent jest używany w client sideowym ScrollArea na landingu, więc komponent asyncowy stawał sie klientowy i crashowało całą apkę. Teraz SanitizedContent jest po prostu klientowe